### PR TITLE
chore: update SDK to v1.0.2-beta09

### DIFF
--- a/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Assets/Plugins/Android/mainTemplate.gradle
@@ -6,7 +6,7 @@
             url "https://maven.google.com"
         }
         maven {
-            url "https://android-sdk.is.com" // Assets/Tapsell/Mediation/Adapter/IronSource/Editor/IronSourceAdapterDependencies.xml:6, Assets/Tapsell/Mediation/Adapter/Admob/Editor/AdmobAdapterDependencies.xml:7, Assets/Tapsell/Mediation/Adapter/Applovin/Editor/ApplovinAdapterDependencies.xml:7, Assets/Tapsell/Mediation/Adapter/Mintegral/Editor/MintegralAdapterDependencies.xml:8
+            url "https://android-sdk.is.com" // Assets/Tapsell/Mediation/Adapter/IronSource/Editor/IronSourceAdapterDependencies.xml:6, Assets/Tapsell/Mediation/Adapter/Admob/Editor/AdmobAdapterDependencies.xml:7, Assets/Tapsell/Mediation/Adapter/Applovin/Editor/ApplovinAdapterDependencies.xml:7, Assets/Tapsell/Mediation/Adapter/Fyber/Editor/FyberAdapterDependencies.xml:7, Assets/Tapsell/Mediation/Adapter/UnityAds/Editor/UnityAdsAdapterDependencies.xml:7, Assets/Tapsell/Mediation/Adapter/Mintegral/Editor/MintegralAdapterDependencies.xml:8
         }
         maven {
             url "https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea" // Assets/Tapsell/Mediation/Adapter/Mintegral/Editor/MintegralAdapterDependencies.xml:8
@@ -22,13 +22,17 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
+    implementation 'androidx.core:core-ktx:1.9.0' // Assets/Tapsell/Mediation/Editor/MediationDependencies.xml:5
+    implementation 'androidx.lifecycle:lifecycle-process:2.6.1' // Assets/Tapsell/Mediation/Editor/MediationDependencies.xml:4
     implementation 'com.google.code.gson:gson:2.8.5' // Assets/GoogleMobileAdsNative/Editor/GoogleMobileAdsNativeDependencies.xml:3
-    implementation 'ir.tapsell.mediation.adapter:admob-unity:1.0.2-beta07' // Assets/Tapsell/Mediation/Adapter/Admob/Editor/AdmobAdapterDependencies.xml:7
-    implementation 'ir.tapsell.mediation.adapter:applovin-unity:1.0.2-beta07' // Assets/Tapsell/Mediation/Adapter/Applovin/Editor/ApplovinAdapterDependencies.xml:7
-    implementation 'ir.tapsell.mediation.adapter:ironsource-unity:1.0.2-beta07' // Assets/Tapsell/Mediation/Adapter/IronSource/Editor/IronSourceAdapterDependencies.xml:3
-    implementation 'ir.tapsell.mediation.adapter:legacy-unity:1.0.2-beta07' // Assets/Tapsell/Mediation/Adapter/Legacy/Editor/LegacyAdapterDependencies.xml:3
-    implementation 'ir.tapsell.mediation.adapter:mintegral-unity:1.0.2-beta07' // Assets/Tapsell/Mediation/Adapter/Mintegral/Editor/MintegralAdapterDependencies.xml:8
-    implementation 'ir.tapsell:tapsell-unity:1.0.2-beta07' // Assets/Tapsell/Mediation/Editor/MediationDependencies.xml:3
+    implementation 'ir.tapsell.mediation.adapter:admob-unity:1.0.2-beta09' // Assets/Tapsell/Mediation/Adapter/Admob/Editor/AdmobAdapterDependencies.xml:7
+    implementation 'ir.tapsell.mediation.adapter:applovin-unity:1.0.2-beta09' // Assets/Tapsell/Mediation/Adapter/Applovin/Editor/ApplovinAdapterDependencies.xml:7
+    implementation 'ir.tapsell.mediation.adapter:fyber-unity:1.0.2-beta09' // Assets/Tapsell/Mediation/Adapter/Fyber/Editor/FyberAdapterDependencies.xml:7
+    implementation 'ir.tapsell.mediation.adapter:ironsource-unity:1.0.2-beta09' // Assets/Tapsell/Mediation/Adapter/IronSource/Editor/IronSourceAdapterDependencies.xml:3
+    implementation 'ir.tapsell.mediation.adapter:legacy-unity:1.0.2-beta09' // Assets/Tapsell/Mediation/Adapter/Legacy/Editor/LegacyAdapterDependencies.xml:3
+    implementation 'ir.tapsell.mediation.adapter:mintegral-unity:1.0.2-beta09' // Assets/Tapsell/Mediation/Adapter/Mintegral/Editor/MintegralAdapterDependencies.xml:8
+    implementation 'ir.tapsell.mediation.adapter:unityads-unity:1.0.2-beta09' // Assets/Tapsell/Mediation/Adapter/UnityAds/Editor/UnityAdsAdapterDependencies.xml:7
+    implementation 'ir.tapsell:tapsell-unity:1.0.2-beta09' // Assets/Tapsell/Mediation/Editor/MediationDependencies.xml:3
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/Assets/Sample/Scripts/BannerScene.cs
+++ b/Assets/Sample/Scripts/BannerScene.cs
@@ -18,9 +18,9 @@ public class BannerScene : MonoBehaviour
                 Debug.Log("onBannerAd requestSuccess");
                 _adId = adId;
             },
-            () =>
+            (error) =>
             {
-                Debug.Log("onBannerAd requestFailed");
+                Debug.Log("onBannerAd requestFailed: " + error);
             }
         );
     }

--- a/Assets/Sample/Scripts/InterstitialScene.cs
+++ b/Assets/Sample/Scripts/InterstitialScene.cs
@@ -14,9 +14,9 @@ public class InterstitialScene : MonoBehaviour
                 Debug.Log("onInterstitialAd requestSuccess");
                 _adId = adId;
             },
-            () =>
+            (error) =>
             {
-                Debug.Log("onInterstitialAd requestFailed");
+                Debug.Log("onInterstitialAd requestFailed: " + error);
             }
         );
     }

--- a/Assets/Sample/Scripts/NativeScene.cs
+++ b/Assets/Sample/Scripts/NativeScene.cs
@@ -16,9 +16,9 @@ public class NativeScene : MonoBehaviour
                 Debug.Log("onNativeAd requestSuccess");
                 _adId = adId;
             },
-            () =>
+            (error) =>
             {
-                Debug.Log("onNativeAd requestFailed");
+                Debug.Log("onNativeAd requestFailed: " + error);
             }
         );
     }

--- a/Assets/Sample/Scripts/RewardedScene.cs
+++ b/Assets/Sample/Scripts/RewardedScene.cs
@@ -14,9 +14,9 @@ public class RewardedScene : MonoBehaviour
                 Debug.Log("onRewardedAd requestSuccess");
                 _adId = adId;
             },
-            () =>
+            (error) =>
             {
-                Debug.Log("onRewardedAd requestFailed");
+                Debug.Log("onRewardedAd requestFailed: " + error);
             }
         );
     }

--- a/Assets/Tapsell/Mediation/Adapter/Admob/Editor/AdmobAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/Admob/Editor/AdmobAdapterDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
     <androidPackages>
-        <androidPackage spec="ir.tapsell.mediation.adapter:admob-unity:1.0.2-beta07">
+        <androidPackage spec="ir.tapsell.mediation.adapter:admob-unity:1.0.2-beta09">
             <repositories>
                 <repository>https://android-sdk.is.com</repository>
             </repositories>

--- a/Assets/Tapsell/Mediation/Adapter/Applovin/Editor/ApplovinAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/Applovin/Editor/ApplovinAdapterDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
     <androidPackages>
-        <androidPackage spec="ir.tapsell.mediation.adapter:applovin-unity:1.0.2-beta07">
+        <androidPackage spec="ir.tapsell.mediation.adapter:applovin-unity:1.0.2-beta09">
             <repositories>
                 <repository>https://android-sdk.is.com</repository>
             </repositories>

--- a/Assets/Tapsell/Mediation/Adapter/Chartboost/Editor/ChartboostAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/Chartboost/Editor/ChartboostAdapterDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
 <!--    <androidPackages>-->
-<!--        <androidPackage spec="ir.tapsell.mediation.adapter:chartboost-unity:1.0.2-beta07" />-->
+<!--        <androidPackage spec="ir.tapsell.mediation.adapter:chartboost-unity:1.0.2-beta09" />-->
 <!--            <repositories>-->
 <!--                <repository>https://cboost.jfrog.io/artifactory/chartboost-ads</repository>-->
 <!--                <repository>https://cboost.jfrog.io/ui/native/chartboost-mediation</repository>-->

--- a/Assets/Tapsell/Mediation/Adapter/Fyber/Editor/FyberAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/Fyber/Editor/FyberAdapterDependencies.xml
@@ -1,9 +1,9 @@
 <dependencies>
-<!--    <androidPackages>-->
-<!--        <androidPackage spec="ir.tapsell.mediation.adapter:fyber-unity:1.0.2-beta07">-->
-<!--            <repositories>-->
-<!--                <repository>https://android-sdk.is.com</repository>-->
-<!--            </repositories>-->
-<!--        </androidPackage>-->
-<!--    </androidPackages>-->
+    <androidPackages>
+        <androidPackage spec="ir.tapsell.mediation.adapter:fyber-unity:1.0.2-beta09">
+            <repositories>
+                <repository>https://android-sdk.is.com</repository>
+            </repositories>
+        </androidPackage>
+    </androidPackages>
 </dependencies>

--- a/Assets/Tapsell/Mediation/Adapter/IronSource/Editor/IronSourceAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/IronSource/Editor/IronSourceAdapterDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
     <androidPackages>
-        <androidPackage spec="ir.tapsell.mediation.adapter:ironsource-unity:1.0.2-beta07" />
+        <androidPackage spec="ir.tapsell.mediation.adapter:ironsource-unity:1.0.2-beta09" />
         <repositories>
             <repository>https://android-sdk.is.com</repository>
         </repositories>

--- a/Assets/Tapsell/Mediation/Adapter/Legacy/Editor/LegacyAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/Legacy/Editor/LegacyAdapterDependencies.xml
@@ -1,5 +1,5 @@
 <dependencies>
     <androidPackages>
-        <androidPackage spec="ir.tapsell.mediation.adapter:legacy-unity:1.0.2-beta07" />
+        <androidPackage spec="ir.tapsell.mediation.adapter:legacy-unity:1.0.2-beta09" />
     </androidPackages>
 </dependencies>

--- a/Assets/Tapsell/Mediation/Adapter/Liftoff/Editor/LiftoffAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/Liftoff/Editor/LiftoffAdapterDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
 <!--    <androidPackages>-->
-<!--        <androidPackage spec="ir.tapsell.mediation.adapter:liftoff-unity:1.0.2-beta07">-->
+<!--        <androidPackage spec="ir.tapsell.mediation.adapter:liftoff-unity:1.0.2-beta09">-->
 <!--            <repositories>-->
 <!--                <repository>https://android-sdk.is.com</repository>-->
 <!--            </repositories>-->

--- a/Assets/Tapsell/Mediation/Adapter/Mintegral/Editor/MintegralAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/Mintegral/Editor/MintegralAdapterDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
     <androidPackages>
-        <androidPackage spec="ir.tapsell.mediation.adapter:mintegral-unity:1.0.2-beta07">
+        <androidPackage spec="ir.tapsell.mediation.adapter:mintegral-unity:1.0.2-beta09">
             <repositories>
                 <repository>https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea</repository>
                 <repository>https://android-sdk.is.com</repository>

--- a/Assets/Tapsell/Mediation/Adapter/UnityAds/Editor/UnityAdsAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/UnityAds/Editor/UnityAdsAdapterDependencies.xml
@@ -1,9 +1,9 @@
 <dependencies>
-<!--    <androidPackages>-->
-<!--        <androidPackage spec="ir.tapsell.mediation.adapter:unityads-unity:1.0.2-beta07">-->
-<!--            <repositories>-->
-<!--                <repository>https://android-sdk.is.com</repository>-->
-<!--            </repositories>-->
-<!--        </androidPackage>-->
-<!--    </androidPackages>-->
+    <androidPackages>
+        <androidPackage spec="ir.tapsell.mediation.adapter:unityads-unity:1.0.2-beta09">
+            <repositories>
+                <repository>https://android-sdk.is.com</repository>
+            </repositories>
+        </androidPackage>
+    </androidPackages>
 </dependencies>

--- a/Assets/Tapsell/Mediation/Adapter/Wortise/Editor/WortiseAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/Wortise/Editor/WortiseAdapterDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
 <!--    <androidPackages>-->
-<!--        <androidPackage spec="ir.tapsell.mediation.adapter:wortise-unity:1.0.2-beta07">-->
+<!--        <androidPackage spec="ir.tapsell.mediation.adapter:wortise-unity:1.0.2-beta09">-->
 <!--            <repositories>-->
 <!--                <repository>https://maven.wortise.com/artifactory/public</repository>-->
 <!--                <repository>https://artifact.bytedance.com/repository/pangle</repository>-->

--- a/Assets/Tapsell/Mediation/Adapter/Yandex/Editor/YandexAdapterDependencies.xml
+++ b/Assets/Tapsell/Mediation/Adapter/Yandex/Editor/YandexAdapterDependencies.xml
@@ -1,0 +1,15 @@
+<dependencies>
+<!--    <androidPackages>-->
+<!--        <androidPackage spec="ir.tapsell.mediation.adapter:yandex-unity:1.0.2-beta09"/>-->
+<!--        <repositories>-->
+<!--            <repository>https://maven.google.com/</repository>-->
+<!--            <repository>https://android-sdk.is.com/</repository>-->
+<!--            <repository>https://artifact.bytedance.com/repository/pangle</repository>-->
+<!--            <repository>https://sdk.tapjoy.com/</repository>-->
+<!--            <repository>https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea</repository>-->
+<!--            <repository>https://cboost.jfrog.io/artifactory/chartboost-ads/</repository>-->
+<!--            <repository>https://dl.appnext.com/</repository>-->
+<!--            <repository>https://repo1.maven.org/maven2/</repository>-->
+<!--        </repositories>-->
+<!--    </androidPackages>-->
+</dependencies>

--- a/Assets/Tapsell/Mediation/Editor/MediationDependencies.xml
+++ b/Assets/Tapsell/Mediation/Editor/MediationDependencies.xml
@@ -1,5 +1,7 @@
 <dependencies>
     <androidPackages>
-        <androidPackage spec="ir.tapsell:tapsell-unity:1.0.2-beta07" />
+        <androidPackage spec="ir.tapsell:tapsell-unity:1.0.2-beta09" />
+        <androidPackage spec="androidx.lifecycle:lifecycle-process:2.6.1"/>
+        <androidPackage spec="androidx.core:core-ktx:1.9.0"/>
     </androidPackages>
 </dependencies>

--- a/Assets/Tapsell/Mediation/Editor/Utils/PropertiesHelper.cs
+++ b/Assets/Tapsell/Mediation/Editor/Utils/PropertiesHelper.cs
@@ -88,9 +88,11 @@ namespace Tapsell.Mediation.Editor.Utils
                 {
                     continue;
                 }
-
-                // Succeeded in extracting a key-value pair.
-                properties.Add(pair.Value.Key, pair.Value.Value);
+                
+                if (!properties.ContainsKey(pair.Value.Key))
+                {
+                    properties.Add(pair.Value.Key, pair.Value.Value);
+                }
             }
 
             return properties;

--- a/Assets/Tapsell/Mediation/MediatorAndroidMessageListener.cs
+++ b/Assets/Tapsell/Mediation/MediatorAndroidMessageListener.cs
@@ -15,9 +15,9 @@ namespace Tapsell.Mediation
                 .OnSuccessfulRequest(JsonUtility.FromJson<RequestResponse>(response));
         }
 
-        public void OnFailedRequest(string requestId)
+        public void OnFailedRequest(string response)
         {
-            RequestCourier.Get().OnFailedRequest(requestId);
+            RequestCourier.Get().OnFailedRequest(JsonUtility.FromJson<FailedRequestResponse>(response));
         }
 
         public void OnUserRewarded(string adId)

--- a/Assets/Tapsell/Mediation/Request/FailedRequestResponse.cs
+++ b/Assets/Tapsell/Mediation/Request/FailedRequestResponse.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Tapsell.Mediation.Request
+{
+    [Serializable]
+    public class FailedRequestResponse
+    {
+        public string requestId;
+        public string message;
+
+        public FailedRequestResponse(string requestId, string message)
+        {
+            this.requestId = requestId;
+            this.message = message;
+        }
+    }
+}

--- a/Assets/Tapsell/Mediation/Request/IRequestListener.cs
+++ b/Assets/Tapsell/Mediation/Request/IRequestListener.cs
@@ -5,15 +5,15 @@ namespace Tapsell.Mediation.Request
     public interface IRequestListener
     {
         public void OnSuccess(string adId);
-        public void OnFailure();
+        public void OnFailure(string message);
     }
 
     internal class RequestListenerImpl: IRequestListener
     {
         private readonly Action<string> _onSuccess;
-        private readonly Action _onFailure;
+        private readonly Action<string> _onFailure;
 
-        public RequestListenerImpl(Action<string> onSuccess, Action onFailure)
+        public RequestListenerImpl(Action<string> onSuccess, Action<string> onFailure)
         {
             _onSuccess = onSuccess;
             _onFailure = onFailure;
@@ -24,9 +24,9 @@ namespace Tapsell.Mediation.Request
             _onSuccess(adId);
         }
 
-        public void OnFailure()
+        public void OnFailure(string message)
         {
-            _onFailure();
+            _onFailure(message);
         }
     }
 }

--- a/Assets/Tapsell/Mediation/Request/RequestCourier.cs
+++ b/Assets/Tapsell/Mediation/Request/RequestCourier.cs
@@ -68,9 +68,9 @@ namespace Tapsell.Mediation.Request
         }
 
         // Called on failed request event from the messenger
-        internal void OnFailedRequest(string requestId)
+        internal void OnFailedRequest(FailedRequestResponse response)
         {
-            _listeners[requestId]?.OnFailure();
+            _listeners[response.requestId]?.OnFailure(response.message);
         }
 
         private string InitiateRequest(IRequestListener listener)

--- a/Assets/Tapsell/Mediation/Tapsell.cs
+++ b/Assets/Tapsell/Mediation/Tapsell.cs
@@ -10,7 +10,7 @@ namespace Tapsell.Mediation
 {
     public static class Tapsell
     {
-        public static void RequestRewardedAd(string zoneId, Action<string> onSuccess, Action onFailure)
+        public static void RequestRewardedAd(string zoneId, Action<string> onSuccess, Action<string> onFailure)
         {
             RequestRewardedAd(zoneId, new RequestListenerImpl(onSuccess, onFailure));
         }
@@ -25,7 +25,7 @@ namespace Tapsell.Mediation
         {}
 #endif
 
-        public static void RequestInterstitialAd(string zoneId, Action<string> onSuccess, Action onFailure)
+        public static void RequestInterstitialAd(string zoneId, Action<string> onSuccess, Action<string> onFailure)
         {
             RequestInterstitialAd(zoneId, new RequestListenerImpl(onSuccess, onFailure));
         }
@@ -40,12 +40,12 @@ namespace Tapsell.Mediation
         {}
 #endif
 
-        public static void RequestBannerAd(string zoneId, Action<string> onSuccess, Action onFailure)
+        public static void RequestBannerAd(string zoneId, Action<string> onSuccess, Action<string> onFailure)
         {
             RequestBannerAd(zoneId, new RequestListenerImpl(onSuccess, onFailure));
         }
 
-        public static void RequestBannerAd(string zoneId, BannerSize bannerSize, Action<string> onSuccess, Action onFailure)
+        public static void RequestBannerAd(string zoneId, BannerSize bannerSize, Action<string> onSuccess, Action<string> onFailure)
         {
             RequestBannerAd(zoneId, bannerSize, new RequestListenerImpl(onSuccess, onFailure));
         }
@@ -65,7 +65,7 @@ namespace Tapsell.Mediation
         {}
 #endif
 
-        public static void RequestNativeAd(string zoneId, Action<string> onSuccess, Action onFailure)
+        public static void RequestNativeAd(string zoneId, Action<string> onSuccess, Action<string> onFailure)
         {
             RequestNativeAd(zoneId, new RequestListenerImpl(onSuccess, onFailure));
         }
@@ -76,7 +76,7 @@ namespace Tapsell.Mediation
             else LogParameterError("native ad request");
         }
 
-        public static void RequestMultipleNativeAds(string zoneId, int maximumCount, Action<string> onSuccess, Action onFailure)
+        public static void RequestMultipleNativeAds(string zoneId, int maximumCount, Action<string> onSuccess, Action<string> onFailure)
         {
             RequestMultipleNativeAds(zoneId, maximumCount, new RequestListenerImpl(onSuccess, onFailure));
         }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "com.unity.ai.navigation": "1.1.4",
-    "com.unity.collab-proxy": "2.2.0",
-    "com.unity.ide.rider": "3.0.26",
+    "com.unity.collab-proxy": "2.5.2",
+    "com.unity.ide.rider": "3.0.31",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.mobile.android-logcat": "1.3.2",
+    "com.unity.mobile.android-logcat": "1.4.3",
     "com.unity.test-framework": "1.3.7",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.8.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.2.0",
+      "version": "2.5.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -24,7 +24,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.26",
+      "version": "3.0.31",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -49,7 +49,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.mobile.android-logcat": {
-      "version": "1.3.2",
+      "version": "1.4.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/AndroidResolverDependencies.xml
+++ b/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,12 +1,16 @@
 <dependencies>
   <packages>
+    <package>androidx.core:core-ktx:1.9.0</package>
+    <package>androidx.lifecycle:lifecycle-process:2.6.1</package>
     <package>com.google.code.gson:gson:2.8.5</package>
-    <package>ir.tapsell.mediation.adapter:admob-unity:1.0.2-beta07</package>
-    <package>ir.tapsell.mediation.adapter:applovin-unity:1.0.2-beta07</package>
-    <package>ir.tapsell.mediation.adapter:ironsource-unity:1.0.2-beta07</package>
-    <package>ir.tapsell.mediation.adapter:legacy-unity:1.0.2-beta07</package>
-    <package>ir.tapsell.mediation.adapter:mintegral-unity:1.0.2-beta07</package>
-    <package>ir.tapsell:tapsell-unity:1.0.2-beta07</package>
+    <package>ir.tapsell.mediation.adapter:admob-unity:1.0.2-beta09</package>
+    <package>ir.tapsell.mediation.adapter:applovin-unity:1.0.2-beta09</package>
+    <package>ir.tapsell.mediation.adapter:fyber-unity:1.0.2-beta09</package>
+    <package>ir.tapsell.mediation.adapter:ironsource-unity:1.0.2-beta09</package>
+    <package>ir.tapsell.mediation.adapter:legacy-unity:1.0.2-beta09</package>
+    <package>ir.tapsell.mediation.adapter:mintegral-unity:1.0.2-beta09</package>
+    <package>ir.tapsell.mediation.adapter:unityads-unity:1.0.2-beta09</package>
+    <package>ir.tapsell:tapsell-unity:1.0.2-beta09</package>
   </packages>
   <files />
   <settings>

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -137,7 +137,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0
+  bundleVersion: 1.0.2-beta09
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -248,6 +248,7 @@ PlayerSettings:
   useCustomLauncherGradleManifest: 0
   useCustomBaseGradleTemplate: 1
   useCustomGradlePropertiesTemplate: 1
+  useCustomGradleSettingsTemplate: 0
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 3
   AndroidTargetDevices: 0
@@ -268,7 +269,6 @@ PlayerSettings:
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
   chromeosInputEmulation: 1
-  AndroidMinifyWithR8: 0
   AndroidMinifyRelease: 0
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.40f1
-m_EditorVersionWithRevision: 2021.3.40f1 (6fcab7dbbbc1)
+m_EditorVersion: 2021.3.45f1
+m_EditorVersionWithRevision: 2021.3.45f1 (0da89fac8e79)


### PR DESCRIPTION
- Update Tapsell Mediation SDK to `v1.0.2-beta09`
- Added error message in onFailure callback in sample scenes
- Fixed showing close icon in interstitial banner when rotation happens in Tapsell Legacy ads.
- Update Unity Editor to `v2021.3.45f1`